### PR TITLE
Allow processing of relative links to any ExtraFileObject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - bin/rake
     - vendor/bundle/**/*
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for relative links to all extra files, not just markdown ([#9](https://github.com/haines/yard-relative_markdown_links/pull/9))
 
 ## [0.2.0] - 2020-03-06
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A [YARD](https://yardoc.org) plugin to allow relative links between Markdown files.
 
 GitHub and YARD render Markdown files differently.
-In particular, relative links between Markdown files that work in GitHub don't work in YARD.
+In particular, relative links in Markdown files that work in GitHub don't work in YARD.
 For example, if you have `[hello](FOO.md)` in your README, YARD renders it as `<a href="FOO.md">hello</a>`, creating a broken link in your docs.
 
 With this plugin enabled, you'll get `<a href="file.FOO.html">hello</a>` instead, which correctly links through to the rendered HTML file.
@@ -52,6 +52,8 @@ To include all Markdown files in your project, add the following lines to the en
 -
 **/*.md
 ```
+
+If you include other types of file, relative links to those files from Markdown will work as well.
 
 
 ## Development

--- a/lib/yard/relative_markdown_links.rb
+++ b/lib/yard/relative_markdown_links.rb
@@ -2,7 +2,9 @@
 
 require "nokogiri"
 require "yard"
+require "uri"
 require "yard/relative_markdown_links/version"
+
 
 module YARD # rubocop:disable Style/Documentation
   # GitHub and YARD render Markdown files differently. In particular, relative
@@ -13,14 +15,15 @@ module YARD # rubocop:disable Style/Documentation
   # With this plugin enabled, you'll get `<a href="file.FOO.html">hello</a>`
   # instead, which correctly links through to the rendered HTML file.
   module RelativeMarkdownLinks
-    # Resolves relative links to Markdown files.
+    # Resolves relative links from Markdown files.
     # @param [String] text the HTML fragment in which to resolve links.
-    # @return [String] HTML with relative links to Markdown files converted to `{file:}` links.
+    # @return [String] HTML with relative links to extra files converted to `{file:}` links.
     def resolve_links(text)
       html = Nokogiri::HTML.fragment(text)
       html.css("a[href]").each do |link|
         href = URI(link["href"])
-        next unless href.relative? && markup_for_file(nil, href.path) == :markdown
+
+        next unless href.relative? && options.files.map(&:filename).include?(href.path)
 
         link.replace "{file:#{href} #{link.inner_html}}"
       end

--- a/lib/yard/relative_markdown_links.rb
+++ b/lib/yard/relative_markdown_links.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 require "nokogiri"
-require "yard"
 require "uri"
+require "yard"
 require "yard/relative_markdown_links/version"
-
 
 module YARD # rubocop:disable Style/Documentation
   # GitHub and YARD render Markdown files differently. In particular, relative

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,4 @@
 
 require "minitest/autorun"
 require "yard/relative_markdown_links"
-require 'ostruct'
+require "ostruct"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,4 @@
 
 require "minitest/autorun"
 require "yard/relative_markdown_links"
+require 'ostruct'

--- a/test/yard/relative_markdown_links_test.rb
+++ b/test/yard/relative_markdown_links_test.rb
@@ -12,6 +12,15 @@ module YARD
         def resolve_links(text)
           text
         end
+
+        def options
+          OpenStruct.new(
+            files: [
+              OpenStruct.new(filename: 'world.md'),
+              OpenStruct.new(filename: 'planet.yaml')
+            ]
+          )
+        end
       }.new
     end
 
@@ -25,6 +34,26 @@ module YARD
       HTML
 
       assert_equal expected_output, @template.resolve_links(input)
+    end
+
+    def test_relative_nonmarkdown_links
+      input = <<~HTML
+        <p>Hello, <a href="planet.yaml">Planet</a></p>
+      HTML
+
+      expected_output = <<~HTML
+        <p>Hello, {file:planet.yaml Planet}</p>
+      HTML
+
+      assert_equal expected_output, @template.resolve_links(input)
+    end
+
+    def test_relative_links_to_unincluded_files
+      input = <<~HTML
+        <p>Hello, <a href="moon.md">Moon</a></p>
+      HTML
+
+      assert_equal input, @template.resolve_links(input)
     end
 
     def test_absolute_markdown_links

--- a/test/yard/relative_markdown_links_test.rb
+++ b/test/yard/relative_markdown_links_test.rb
@@ -16,8 +16,8 @@ module YARD
         def options
           OpenStruct.new(
             files: [
-              OpenStruct.new(filename: 'world.md'),
-              OpenStruct.new(filename: 'planet.yaml')
+              OpenStruct.new(filename: "world.md"),
+              OpenStruct.new(filename: "planet.yaml")
             ]
           )
         end


### PR DESCRIPTION
This allows the plugin to process relative links _from_ Markdown to any target that is included as an ExtraFileObject, regardless of whether the target file in Markdown-formatted or not.

Fixes #8 